### PR TITLE
Handle values with spaces correctly

### DIFF
--- a/library/uci
+++ b/library/uci
@@ -12,7 +12,7 @@ unquoted_key="$(echo $key | sed -e s/\'//g)"
 # test if we need to apply a change
 case $command in
     'set')
-        [ $(uci get "$unquoted_key") = "$value" ]
+        [ "$(uci get "$unquoted_key")" = "$value" ]
         changed=$?
         ;;
     'add_list')

--- a/library/uci
+++ b/library/uci
@@ -5,16 +5,7 @@
 # TODO: add more docs, see http://docs.ansible.com/developing_modules.html
 
 # parameters are command, key, value
-for param in $(cat ${1})
-do
-    case "$param" in
-        command=*|key=*|value=*)
-            eval "$param"
-            ;;
-        *)
-            ;;
-    esac
-done
+source ${1}
 
 unquoted_key="$(echo $key | sed -e s/\'//g)"
 


### PR DESCRIPTION
The uci module does not handle values with spaces correctly.  For example, a playbook containing the following part will fail:

``` yaml
  wireless:
    - key: key
      value: "secret passphrase"
      ifaces: [0]
```
