### PR TITLE
Do not escape quotes for values

### DIFF
--- a/library/uci
+++ b/library/uci
@@ -8,6 +8,7 @@
 source ${1}
 
 unquoted_key="$(echo $key | sed -e s/\'//g)"
+unquoted_value="$(echo $value | sed -e s/\'//g)"
 
 # test if we need to apply a change
 case $command in
@@ -27,7 +28,7 @@ then
 else
     if [ -z "${_ansible_check_mode}" -o "${_ansible_check_mode}" = "False" ]
     then
-        logger uci $(uci "${command}" ${unquoted_key}="${value}")
+        logger uci $(uci "${command}" ${unquoted_key}="${unquoted_value}")
     fi
     echo -n '{"changed": true, "msg": "executed uci '${command}' '${unquoted_key}'='${value}'"}'
 fi


### PR DESCRIPTION
Hi @lefant,

Thanks for your work on openwrt / ansible modules. They helped me understand how to tie openwrt and ansible together.

I found however some issue related with the value with spaces.

Consider the following scenario.

Given that I have the following vars defined in yaml file:

```
---
network:
  dns: '8.8.8.8 8.8.4.4'
```

When running task:

```
---
- uci: command=set key='network.wan.{{ item.key }}' value='{{ item.value }}'
  with_dict: '{{ network }}'

  notify:
   - uci commit
```

Then I get:

```
config interface 'wan'
  option dns ''\''8.8.8.8 8.8.4.4'\'''
```

Instead of:

```
config interface 'wan'
  option dns '8.8.8.8 8.8.4.4'
```